### PR TITLE
Update LogHelper.java

### DIFF
--- a/api/src/main/java/ca/bc/gov/educ/api/gradstudent/util/LogHelper.java
+++ b/api/src/main/java/ca/bc/gov/educ/api/gradstudent/util/LogHelper.java
@@ -83,7 +83,7 @@ public final class LogHelper {
   public static void logMessagingEventDetails(final String event) {
     try {
       MDC.putCloseable("messageEvent", event);
-      log.info("");
+      log.debug("");
       MDC.clear();
     } catch (final Exception exception) {
       log.error(EXCEPTION, exception);


### PR DESCRIPTION
NATS message log level is changed to DEBUG only.  It will not generate a NATS message payload log at INFO level.