### PR TITLE
Security: Dependabot findings.

### DIFF
--- a/.github/workflows/on.pr.yml
+++ b/.github/workflows/on.pr.yml
@@ -21,8 +21,9 @@ jobs:
         with:
           fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
       - name: Set up JDK 18
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v4
         with:
+          distribution: 'corretto'
           java-version: 18
       - uses: actions/cache@v1
         with:

--- a/api/pom.xml
+++ b/api/pom.xml
@@ -35,8 +35,8 @@
         <shedlock.version>4.38.0</shedlock.version>
         <nats.version>2.11.0</nats.version>
         <resilience4j.version>1.7.1</resilience4j.version>
-        <guava.version>32.0.1-jre</guava.version>
-        <log4j.version>2.18.0</log4j.version>
+        <guava.version>33.4.0-jre</guava.version>
+        <log4j.version>2.20.0</log4j.version>
     </properties>
 
     <parent>
@@ -205,7 +205,7 @@
         <dependency>
             <groupId>org.flywaydb</groupId>
             <artifactId>flyway-core</artifactId>
-            <version>8.5.13</version>
+            <version>11.2.0</version>
         </dependency>
         <dependency>
             <groupId>io.github.resilience4j</groupId>
@@ -265,7 +265,7 @@
         <plugin>
           <groupId>org.hibernate.orm.tooling</groupId>
           <artifactId>hibernate-enhance-maven-plugin</artifactId>
-          <version>6.1.7.Final</version>
+          <version>6.6.4.Final</version>
         </plugin>
         <plugin>
           <groupId>org.springframework.boot</groupId>
@@ -357,7 +357,7 @@
           <plugin>
             <groupId>org.hibernate.orm.tooling</groupId>
             <artifactId>hibernate-enhance-maven-plugin</artifactId>
-            <version>6.1.7.Final</version>
+            <version>6.6.4.Final</version>
             <executions>
               <execution>
                 <configuration>


### PR DESCRIPTION
Change Details:
- Bump org.flywaydb:flyway-core from 8.5.13 to 11.2.0 in /api 
- Bump org.hibernate.orm.tooling:hibernate-enhance-maven-plugin from 6.1.7.Final to 6.6.4.Final in /api 
- Bump com.google.guava:guava from 32.0.1-jre to 33.4.0-jre in /api 
- Bump log4j.version from 2.18.0 to 2.20.0
- Bump actions/setup-java from 1 to 4 